### PR TITLE
set unavailable when bluetooth connection fails

### DIFF
--- a/custom_components/ember_mug/coordinator.py
+++ b/custom_components/ember_mug/coordinator.py
@@ -86,6 +86,7 @@ class MugDataUpdateCoordinator(DataUpdateCoordinator):
             self.available = True
         except Exception as e:
             _LOGGER.error(e)
+            self.available = False
             raise UpdateFailed(f"An error occurred updating mug: {e=}")
         _LOGGER.debug(f"Changed: {changed}")
         _LOGGER.debug("Update done")


### PR DESCRIPTION
It seems if bluetooth gets disconnected (or fails for another reason), a stale state shows - this should trigger to instead show the mug as "unavailable" in HA